### PR TITLE
Resolve boundary marker (.#.) conflict with comments

### DIFF
--- a/syntaxes/xfscript.tmLanguage.json
+++ b/syntaxes/xfscript.tmLanguage.json
@@ -28,7 +28,7 @@
 		"comments": {
 			"patterns": [{
 				"name": "comment.line.exclamation-mark.lexc",
-				"match": "(?<!\\.)#.*|(?<=\\.)#(?![\\.]).*"
+				"match": "(?<!\\.)#.*|(?<=\\.)#(?!\\.).*"
 			}]
 		},
 		"defines": {

--- a/syntaxes/xfscript.tmLanguage.json
+++ b/syntaxes/xfscript.tmLanguage.json
@@ -28,7 +28,7 @@
 		"comments": {
 			"patterns": [{
 				"name": "comment.line.exclamation-mark.lexc",
-				"match": "#.*"
+				"match": "(?<!\\.)#.*|(?<=\\.)#(?![\\.]).*"
 			}]
 		},
 		"defines": {


### PR DESCRIPTION
Adjust the regular expression for comments so that the pound sign in the boundary marker (.#.) is not treated as a start of a comment.

Tested cases:
```
"#."     -> "#." is matched
".#"     -> "#" is matched
".#."    -> nothing is matched
"#.#."   -> "#.#." is matched
"#abc."  -> "#abc." is matched
```